### PR TITLE
Replace `Element.contains` with `Element.compareDocumentPosition`

### DIFF
--- a/src/wysihtml5/views/composer_selection_event.js
+++ b/src/wysihtml5/views/composer_selection_event.js
@@ -43,7 +43,8 @@ Composer.prototype._fireSelectionChange = function() {
   var returnValue = null;
   if (range) {
     var nativeRange = range.nativeRange;
-    if (this.element.contains(nativeRange.commonAncestorContainer)) {
+    var position = this.element.compareDocumentPosition(nativeRange.commonAncestorContainer);
+    if (position & Node.DOCUMENT_POSITION_CONTAINED_BY) {
       returnValue = nativeRange;
     }
   }


### PR DESCRIPTION
`Element.contains` doesn't work for text nodes in IE10…
