### PR TITLE
Append newlines after block level elements when parsing

### DIFF
--- a/src/wysihtml5/dom/parse.js
+++ b/src/wysihtml5/dom/parse.js
@@ -102,6 +102,17 @@ var Parser = (function() {
       element.removeChild(firstChild);
       if (newNode) {
         fragment.appendChild(newNode);
+        if (lang.array([
+                "div", "pre", "p",
+                "blockquote",
+                "table", "td", "th",
+                "ul", "ol", "li",
+                "dd", "dl",
+                "footer", "header", "section",
+                "h1", "h2", "h3", "h4", "h5", "h6"
+            ]).contains(newNode.nodeName.toLowerCase())) {
+              fragment.appendChild(document.createTextNode("\n\n"));
+        }
       }
     }
 


### PR DESCRIPTION
https://next.getflow.com/workspaces/1/tasks/5603507

Should we make this a parser rule or just have it behave this way all the time?
