### PR TITLE
Fix bug with pasting that can result in unwrapped text nodes

### DIFF
--- a/src/wysihtml5/views/composer_observer.js
+++ b/src/wysihtml5/views/composer_observer.js
@@ -80,6 +80,13 @@ Composer.prototype.observe = function() {
         host.innerHTML = data;
         that.parent.parse(host);
         var fragment = dom.nodeList.toArray(host.childNodes);
+
+        for (var i = 0; i < fragment.length; i++) {
+          if (fragment[i].nodeType == Node.TEXT_NODE) {
+            fragment[i] = dom.fromPlainText(fragment[i].textContent)[0];
+          }
+        }
+
         that.selection.insertElements(fragment);
       } else if (data = clipboardData.getData("Text")) {
         var fragment = dom.fromPlainText(data);


### PR DESCRIPTION
https://next.getflow.com/workspaces/1/tasks/5603855

The task is about blockquotes not working but the reason for it not working is due to a pasting bug... sometimes text is pasted in the wysiwyg div and isn't wrapped in any tags, so the main wysiwyg div is replaced with a blockquote instead of the wrapping tag.  

This checks when you paste html to make sure that every node is wrapped in an element before it's appended to the wysiwyg div.
