### PR TITLE
Normalize DOM tree before comparing

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
     "wd": "~0.2.5",
     "mocha-as-promised": "~1.4.1",
     "chai-as-promised": "~4.1.0",
-    "grunt-mocha-selenium": "git://github.com/mogstad/grunt-mocha-selenium"
+    "grunt-mocha-selenium": "git://github.com/mogstad/grunt-mocha-selenium",
+    "jsdom": "~0.8.10",
+    "rsvp": "~2.0.4"
   }
 }

--- a/test/integration_tests/lib/approximately_equals_html_string.js
+++ b/test/integration_tests/lib/approximately_equals_html_string.js
@@ -1,0 +1,93 @@
+var jsdom = require("jsdom");
+var RSVP = require("rsvp");
+var chai = require("chai");
+var expect = chai.expect;
+
+var Assertion = chai.Assertion;
+var assert = chai.assert;
+
+Assertion.addMethod("equalNode", function (b) {
+  var _this = this;
+  var a = this._obj;
+
+  this.assert(a.isEqualNode(b),
+              "expected node to equal #{exp} but it was #{act}",
+              "expected node to not equal #{exp} but it was",
+              b.innerHTML,
+              a.innerHTML);
+});
+
+var approximatelyEqualsHTMLString = function(a, b) {
+  return RSVP.all([normalize(a), normalize(b)]).then(function(windows) {
+    expect(windows[0].document.body).to.be.equalNode(windows[1].document.body)
+  });
+};
+
+var normalize = function(html) {
+  return setupDOM(html).then(function(window) {
+    var body = window.document.body;
+    body.normalize();
+    cleanupChildNodes(body);
+    removeSingleEmptyBreakLine(body);
+    return window;
+  });
+};
+
+var removeSingleEmptyBreakLine = function(node) {
+  var children = node.childNodes;
+  for (var index = children.length - 1; index >= 0; index--) {
+    var childNode = children[index];
+    switch (childNode.nodeType) {
+      case childNode.TEXT_NODE:
+        childNode.nodeValue = childNode.nodeValue.replace(/\uFEFF/, "");
+        break;
+      case childNode.ELEMENT_NODE:
+        if (childNode.nodeName == "BR") {
+          if (node.lastChild == childNode && childNode.previousSibling && childNode.previousSibling.nodeName != "BR") {
+            node.removeChild(childNode);
+          }
+        } else {
+          removeSingleEmptyBreakLine(childNode);
+        }
+        break;
+    }
+  };
+};
+
+var cleanupChildNodes = function(node) {
+  var children = node.childNodes
+  for (var index = children.length - 1; index >= 0; index--) {
+    var childNode = children[index];
+    switch (childNode.nodeType) {
+      case childNode.TEXT_NODE:
+        if (!childNode.nodeValue) {
+          node.removeChild(childNode);
+        }
+        break;
+      case childNode.ELEMENT_NODE:
+        cleanupChildNodes(childNode);
+        break;
+      case childNode.COMMENT_NODE:
+        node.removeChild(childNode);
+        break;
+    }
+  };
+};
+
+var setupDOM = function(html) {
+  return new RSVP.Promise(function(resolve, revoke) {
+    jsdom.env(
+      html,
+      [],
+      function (errors, window) {
+        if (errors) {
+          revoke(errors);
+        } else {
+          resolve(window);
+        }
+      }
+    );
+  });
+};
+
+module.exports = approximatelyEqualsHTMLString;

--- a/test/integration_tests/lib/content.js
+++ b/test/integration_tests/lib/content.js
@@ -1,9 +1,13 @@
 var chai = require("chai");
 var Assertion = chai.Assertion;
+var approximatelyEqualsHTMLString = require("../lib/approximately_equals_html_string");
 
-function ContentShouldEqual(item, shouldEqual) {
+function ContentShouldEqual(item, shouldEqual, debug) {
   return browser.execute("return arguments[0].innerHTML;", [item]).then(function(content) {
-    new Assertion(content).to.equal(shouldEqual);
+    if (debug) {
+      console.log("Content: ", content);
+    }
+    return approximatelyEqualsHTMLString(content, shouldEqual);
   });
 };
 

--- a/test/integration_tests/text_substitutions/auto_list.test.js
+++ b/test/integration_tests/text_substitutions/auto_list.test.js
@@ -23,13 +23,13 @@ describe("Auto Listing", function() {
     unorderedOptions.forEach(function(option) {
       it("should auto-list an unordered list by typing "+ option, function() {
         return editor.type(option +" test").then(function() {
-          return ContentShouldEqual(editor, "<ul><li>test<br></li></ul>");
+          return ContentShouldEqual(editor, "<ul><li>test</li></ul>");
         });
       });
 
       it ("should not auto list inside a list-item, by typing "+ option, function() {
         return editor.type(option +" "+ option +" test").then(function() {
-          return ContentShouldEqual(editor, "<ul><li>"+ option +" test<br></li></ul>");
+          return ContentShouldEqual(editor, "<ul><li>"+ option +" test</li></ul>");
         });
       });
     });
@@ -38,13 +38,13 @@ describe("Auto Listing", function() {
   context("ordered lists", function() {
     it("Should auto-list an ordered list by typing `1.`", function() {
       return editor.type("1. test").then(function() {
-        return ContentShouldEqual(editor, "<ol><li>test<br></li></ol>");
+        return ContentShouldEqual(editor, "<ol><li>test</li></ol>");
       });
     });
 
     it("should not auto list inside a list-item, by typing 1.", function() {
        return editor.type("1. 1. test").then(function() {
-        return ContentShouldEqual(editor, "<ol><li>1. test<br></li></ol>");
+        return ContentShouldEqual(editor, "<ol><li>1. test</li></ol>");
       });
     });
   });
@@ -52,7 +52,7 @@ describe("Auto Listing", function() {
   ["*", "-", "•", "1."].forEach(function(option) {
     it("should only auto-list—by typing `"+ option +"`—if the committed word is at the beginning of its block element", function() {
       return editor.type("test "+ option +" test").then(function() {
-        return ContentShouldEqual(editor, "<p>test "+ option +" test<br></p>");
+        return ContentShouldEqual(editor, "<p>test "+ option +" test</p>");
       });
     });
   });


### PR DESCRIPTION
Remove irrelevant content from the DOM tree before comparing it.

Removes:
- comments
- empty text node.
- single trailing `br` elements
- `\uFEFF`—invisible space
