### PR TITLE
Remove extra whitespace

### DIFF
--- a/src/wysihtml5/dom/remove_empty_nodes.js
+++ b/src/wysihtml5/dom/remove_empty_nodes.js
@@ -7,24 +7,27 @@
  */
 
 var removeEmptyNodes = function(node) {
-  var element, firstNode, lastNode, firstNodeText, lastNodeText;
+  var index, lastNodeIndex, element, firstNode, lastNode, firstNodeText, lastNodeText;
   element = node.cloneNode(true);
-
+  index = 0;
   while (element.childNodes.length) {
-    firstNode = element.childNodes[0];
-    lastNode = element.childNodes[element.childNodes.length - 1];
+    lastNodeIndex = Math.max(element.childNodes.length - 1, 0)
+    firstNode = element.childNodes[index];
+    lastNode = element.childNodes[lastNodeIndex];
     firstNodeText = (firstNode.textContent || "").trim();
     lastNodeText = (lastNode.textContent || "").trim();
 
     if (!firstNodeText) {
       element.removeChild(firstNode);
+    } else {
+      index++;
     }
 
     if (!lastNodeText && lastNode != firstNode) {
       element.removeChild(lastNode);
     }
 
-    if (firstNodeText && lastNodeText) {
+    if (index >= lastNodeIndex) {
       break;
     }
   }

--- a/src/wysihtml5/dom/remove_trailing_line_breaks.js
+++ b/src/wysihtml5/dom/remove_trailing_line_breaks.js
@@ -8,7 +8,8 @@
 import { nodeList } from "./node_list";
 
 var removeTrailingLineBreaks = function(node) {
-  var childNodes = nodeList.toArray(node.querySelectorAll("br:last-child"));
+  var element = node.cloneNode(true);
+  var childNodes = nodeList.toArray(element.querySelectorAll("br:last-child"));
 
   for (var index = 0; index < childNodes.length; index++) {
     var childNode = childNodes[index];
@@ -18,7 +19,7 @@ var removeTrailingLineBreaks = function(node) {
     }
   }
 
-  return node;
+  return element;
 };
 
 export { removeTrailingLineBreaks };

--- a/src/wysihtml5/views/composer.js
+++ b/src/wysihtml5/views/composer.js
@@ -44,8 +44,8 @@ var Composer = Base.extend({
     }
 
     if (options.trim) {
-      element = wysihtml5.dom.removeEmptyNodes(element);
       element = wysihtml5.dom.removeTrailingLineBreaks(element);
+      element = wysihtml5.dom.removeEmptyNodes(element);
     }
 
     value = this.isEmpty() ? "" : quirks.getCorrectInnerHTML(element);


### PR DESCRIPTION
- In order to match the markdown editor, remove
  all empty tags instead of just trailing ones.

The name "remove empty nodes" kind of makes it sound like that was supposed to work in the first place anyway....
