### PR TITLE
Cancel scheduled `ensureParagraph` when editor blurs

### DIFF
--- a/src/wysihtml5/views/composer.js
+++ b/src/wysihtml5/views/composer.js
@@ -168,21 +168,24 @@ var Composer = Base.extend({
   },
 
   _initLineBreaking: function() {
-    var that = this,
-        _this = this;
+    var timeout;
+
+    dom.observe(this.element, "blur", function(e) {
+      clearTimeout(timeout);
+    }.bind(this))
 
     dom.observe(this.element, ["focus", "keydown"], function(e) {
       if (e.type == "focus" || e.keyCode == Constants.BACKSPACE_KEY) {
-        setTimeout(function() {
-          that.ensureParagraph();
-        }, 0);
+        timeout = setTimeout(function() {
+          this.ensureParagraph();
+        }.bind(this), 0);
       }
-    });
+    }.bind(this));
 
     dom.observe(this.element, "keydown", function(event) {
-      _this._handleKeyboardHandlers(event);
-      _this._lookForTextSubstitution(event);
-    });
+      this._handleKeyboardHandlers(event);
+      this._lookForTextSubstitution(event);
+    }.bind(this));
   },
 
   ensureParagraph: function() {


### PR DESCRIPTION
Composer ensures that there is a paragraph when focusing the composer.
It runs it in a timeout and it could get blurred in the meantime which
would result in that the composer would get focused again.
