### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "broccoli-es6-concatenator": "0.1.4",
     "broccoli-static-compiler": "0.1.4",
     "broccoli-merge-trees": "0.1.3",
-    "broccoli-dist-es6-module": "0.1.8",
+    "broccoli-dist-es6-module": "0.2.0",
     "broccoli-replace": "0.1.5",
     "broccoli-concat": "0.0.3",
     "broccoli-global-export": "git://github.com/mogstad/broccoli-global-export.git"


### PR DESCRIPTION
`npm install` would fail with `0.1.8` - That version seemed to list a dependency on a version of `broccoli-static-compiler` (0.0.5) that couldn't be found.
