### PR TITLE
Only remove trailing new-lines

### DIFF
--- a/src/wysihtml5/dom/remove_trailing_line_breaks.js
+++ b/src/wysihtml5/dom/remove_trailing_line_breaks.js
@@ -9,12 +9,12 @@ import { nodeList } from "./node_list";
 
 var removeTrailingLineBreaks = function(node) {
   var element = node.cloneNode(true);
+  element.normalize();
   var childNodes = nodeList.toArray(element.querySelectorAll("br:last-child"));
-
   for (var index = 0; index < childNodes.length; index++) {
     var childNode = childNodes[index];
     var previousSibling = childNode.previousSibling;
-    if(!previousSibling || (previousSibling && previousSibling.nodeName != "BR")) {
+    if ((!previousSibling || (previousSibling && previousSibling.nodeName != "BR")) && !childNode.nextSibling) {
       childNode.parentNode.removeChild(childNode);
     }
   }


### PR DESCRIPTION
Make sure `RemoveTrailingLineBreaks` doesn’t remove line breaks that has
text-nodes as its next sibling
