### PR TITLE
Don't lose newline data if it's inside an otherwise empty element

### DIFF
--- a/src/wysihtml5/dom/remove_empty_nodes.js
+++ b/src/wysihtml5/dom/remove_empty_nodes.js
@@ -17,6 +17,15 @@ var removeEmptyNodes = function(node) {
       var nodeContainsImage = node.nodeName == "IMG" || (node.nodeType == Node.ELEMENT_NODE && node.querySelector("img"));
       var nodeHasTextContent = (node.textContent || "").trim();
       if (!nodeContainsImage && !nodeHasTextContent) {
+        var nodeContainsLineBreak = node.nodeName == "BR" || (node.nodeType == Node.ELEMENT_NODE && node.querySelector("br"));
+
+        if (nodeContainsLineBreak) {
+          var totalLineBreaks = node.nodeType == Node.ELEMENT_NODE ? node.querySelectorAll("br").length : 1;
+          for (var lineBreakIndex = 0; lineBreakIndex < totalLineBreaks; lineBreakIndex++) {
+            element.insertBefore(document.createElement("br"), node);
+          }
+        }
+
         element.removeChild(node);
       }
     }

--- a/src/wysihtml5/views/composer.js
+++ b/src/wysihtml5/views/composer.js
@@ -45,8 +45,8 @@ var Composer = Base.extend({
     }
 
     if (options.trim) {
-      element = dom.removeTrailingLineBreaks(element);
       element = dom.removeEmptyNodes(element);
+      element = dom.removeTrailingLineBreaks(element);
     }
 
     value = !containsContent(element) ? "" : quirks.getCorrectInnerHTML(element);


### PR DESCRIPTION
Our RemoveEmptyElements method was removing nodes that had a bunch of empty <br>
tags, which meant that newlines were being stripped.

Sort of an edge case that you'd only hit if you entered in text that didn't have
a wrapping paragraph.

I'm not even sure how this is possible as we always ensure a paragraph when
values are inserted into the textara.

Some commentary on the root cause of the issue here - https://app.bananastand.org/organizations/52/teams/1/tasks/5677662

I don't want to block the support ticket but I would like to know how this happened so we can fix it properly!